### PR TITLE
Fix two UndefVarErrors

### DIFF
--- a/src/material.jl
+++ b/src/material.jl
@@ -96,7 +96,7 @@ function Base.setproperty!(obj::OcclusionTextureInfo, sym::Symbol, x)
     elseif sym === :texCoord && x !== nothing
         x ≥ 0 || throw(ArgumentError("the set index of texture's TEXCOORD attribute used for texture coordinate mapping should be ≥ 0"))
     elseif sym === :strength && x !== nothing
-        0 ≤ strength ≤ 1 || throw(ArgumentError("strength should be should be ≥ 0 and ≤ 1"))
+        0 ≤ x ≤ 1 || throw(ArgumentError("strength should be should be ≥ 0 and ≤ 1"))
     end
     setfield!(obj, sym, x)
 end
@@ -141,7 +141,7 @@ function Base.setproperty!(obj::PBRMetallicRoughness, sym::Symbol, x)
     elseif sym === :metallicFactor && x !== nothing
         0 ≤ x ≤ 1 || throw(ArgumentError("the metalness of the material factor should ≥ 0 and ≤ 1"))
     elseif sym === :roughnessFactor && x !== nothing
-        0 ≤ roughnessFactor ≤ 1 || throw(ArgumentError("the roughness of the material factor should ≥ 0 and ≤ 1"))
+        0 ≤ x ≤ 1 || throw(ArgumentError("the roughness of the material factor should ≥ 0 and ≤ 1"))
     end
     setfield!(obj, sym, x)
 end


### PR DESCRIPTION
Fix for these
```
using GLTF
o = GLTF.OcclusionTextureInfo()
o.strength = 0.1f0
```
gives
```
ERROR: UndefVarError: `strength` not defined
Stacktrace:
 [1] setproperty!(obj::GLTF.OcclusionTextureInfo, sym::Symbol, x::Float32)
   @ GLTF C:\Users\jaakkor2\.julia\packages\GLTF\t9Xw9\src\material.jl:99
 [2] top-level scope
   @ REPL[5]:1
```

and
```
using GLTF
p = GLTF.PBRMetallicRoughness()
p.roughnessFactor = 0.1f0
```
gives
```
ERROR: UndefVarError: `roughnessFactor` not defined
Stacktrace:
 [1] setproperty!(obj::GLTF.PBRMetallicRoughness, sym::Symbol, x::Float32)
   @ GLTF C:\Users\jaakkor2\.julia\packages\GLTF\t9Xw9\src\material.jl:144
 [2] top-level scope
   @ REPL[3]:1
```